### PR TITLE
raspbootcom bugfix: Free file descriptors after use.

### DIFF
--- a/raspbootcom/raspbootcom.cc
+++ b/raspbootcom/raspbootcom.cc
@@ -183,7 +183,9 @@ void send_kernel(int fd, const char *file) {
     }
 
     fprintf(stderr, "### finished sending\n");
-
+    
+    close(file_fd);
+    
     return;
 }
 


### PR DESCRIPTION
If the raspbootin on the serial requests a lot of kernels, raspbootcom will exhaust the file descriptor limit, as it's not freeing them after sending each kernel.

This trivial pull fixes that.
