### PR TITLE
Raspbootcom, fixed: unterminated RX string leading to garbage output

### DIFF
--- a/raspbootcom/raspbootcom.cc
+++ b/raspbootcom/raspbootcom.cc
@@ -320,6 +320,7 @@ int main(int argc, char *argv[]) {
 		    case 0:
 			done = true;
 		    }
+        buf2[len] = '\0';
 		    // scan output for tripple break (^C^C^C)
 		    // send kernel on tripple break, otherwise output text
 		    const char *p = buf2;


### PR DESCRIPTION
Raspbootcom used to add random bytes to my application output. this fixes this.
Some people might prefer a memset... whatever :)
