### PR TITLE
resetting terminal on exit

### DIFF
--- a/raspbootcom/raspbootcom.cc
+++ b/raspbootcom/raspbootcom.cc
@@ -29,6 +29,7 @@
 #include <endian.h>
 #include <stdint.h>
 #include <termios.h>
+#include <signal.h>
 
 #define BUF_SIZE 65536
 
@@ -42,6 +43,12 @@ void do_exit(int fd, int res) {
 	tcsetattr(STDIN_FILENO,TCSANOW,&old_tio);
     }
     exit(res);
+}
+
+void reset_terminal(int) {
+   if (isatty(STDIN_FILENO)) {
+    tcsetattr(STDIN_FILENO,TCSANOW,&old_tio);
+    }
 }
 
 // open serial connection
@@ -196,6 +203,8 @@ int main(int argc, char *argv[]) {
     bool done = false, leave = false;
     int breaks = 0;
 
+    signal(SIGINT, reset_terminal);
+    signal(SIGTERM, reset_terminal);
     printf("Raspbootcom V1.0\n");
 
     if (argc != 3) {

--- a/raspbootcom/raspbootcom.cc
+++ b/raspbootcom/raspbootcom.cc
@@ -190,7 +190,9 @@ void send_kernel(int fd, const char *file) {
     }
 
     fprintf(stderr, "### finished sending\n");
-
+    
+    close(file_fd);
+    
     return;
 }
 
@@ -329,6 +331,7 @@ int main(int argc, char *argv[]) {
 		    case 0:
 			done = true;
 		    }
+        buf2[len] = '\0';
 		    // scan output for tripple break (^C^C^C)
 		    // send kernel on tripple break, otherwise output text
 		    const char *p = buf2;


### PR DESCRIPTION
With some terminals the terminal is not reset correctly when exiting with ctl-c. added a signal handler to catch program exits and restore previous terminal settings.
