### PR TITLE
Set serial port to blocking while sending image

### DIFF
--- a/raspbootcom/raspbootcom.cc
+++ b/raspbootcom/raspbootcom.cc
@@ -121,6 +121,12 @@ void send_kernel(int fd, const char *file) {
     return;
   }
 
+  int oflg = UnixError::check("getting tty mode",
+		  fcntl(fd, F_GETFL));
+  oflg &= ~O_NONBLOCK;
+  UnixError::check("clearing non-blocking",
+		  fcntl(fd, F_SETFL, oflg));
+
   while(keep_running && (size > 0)) {
     char buf[BUF_SIZE];
     ssize_t pos = 0;
@@ -134,6 +140,9 @@ void send_kernel(int fd, const char *file) {
       pos += len2;
     }
   }
+  oflg |= O_NONBLOCK;
+  UnixError::check("setting non-blocking",
+		  fcntl(fd, F_SETFL, oflg));
 
   fprintf(stderr, "### finished sending\n\r");
 }


### PR DESCRIPTION
The serial port needs to be in non-blocking mode for normal operation to
use the select() loop. However, if the image being sent is especially
big (e.g. a large operating system), then the write() will eventually
need to block. So clear the non-blocking flag while sending the image,
and then set it once the image is sent.